### PR TITLE
New user

### DIFF
--- a/finetune-frontend/.gitignore
+++ b/finetune-frontend/.gitignore
@@ -22,3 +22,4 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+.env

--- a/finetune-frontend/src/App.jsx
+++ b/finetune-frontend/src/App.jsx
@@ -2,15 +2,21 @@ import { useEffect } from "react";
 import { Routes, Route, useNavigate } from "react-router-dom";
 import Welcome from "./pages/Welcome";
 import Home from "./pages/Home";
+import NewUser from "./pages/NewUser";
 import ProtectedRoute from "./components/ProtectedRoute";
 import { ThemeToggle } from "./components/ThemeToggle";
 import { useAuth } from "./components/AuthProvider";
+
+
+const validPaths = ['/newuser']
 
 function App() {
   const { user, setUser } = useAuth();
   const navigate = useNavigate();
 
-  const ProtectedHome = ProtectedRoute(Home)
+  const ProtectedHome = ProtectedRoute(Home);
+  const ProtectedNewUser = ProtectedRoute(NewUser);
+
 
   useEffect(() => {
     fetch('http://localhost:3000/login/session-status', {credentials: 'include'})
@@ -18,7 +24,9 @@ function App() {
       .then((data)=>{
         if (data.id){
           setUser(data.id);
-          navigate('/home'); //go to home screen if logged in
+          if (!validPaths.includes(window.location.pathname)){ //go to home if you are not on any designated valid paths
+            navigate('/home');
+          }
         } else{
           navigate('/welcome')
         }
@@ -33,6 +41,7 @@ function App() {
       <Routes>
         <Route path="/welcome" element={<Welcome />} />
         <Route path="/home" element={<ProtectedHome />}/>
+        <Route path="/newuser" element={<ProtectedNewUser />} />
         {/*Everything except the welcome page is contingent on the user being logged in*/}
       </Routes>
     </div>

--- a/finetune-frontend/src/App.jsx
+++ b/finetune-frontend/src/App.jsx
@@ -3,12 +3,13 @@ import { Routes, Route, useNavigate } from "react-router-dom";
 import Welcome from "./pages/Welcome";
 import Home from "./pages/Home";
 import NewUser from "./pages/NewUser";
+import LoadUserSpotify from "./pages/LoadUserSpotify";
 import ProtectedRoute from "./components/ProtectedRoute";
 import { ThemeToggle } from "./components/ThemeToggle";
 import { useAuth } from "./components/AuthProvider";
 
 
-const validPaths = ['/newuser']
+const validPaths = ['/newuser', '/loaduserspotify']
 
 function App() {
   const { user, setUser } = useAuth();
@@ -16,15 +17,17 @@ function App() {
 
   const ProtectedHome = ProtectedRoute(Home);
   const ProtectedNewUser = ProtectedRoute(NewUser);
+  const ProtectedLoadSpotify = ProtectedRoute(LoadUserSpotify);
 
 
   useEffect(() => {
-    fetch('http://localhost:3000/login/session-status', {credentials: 'include'})
+    fetch('http://127.0.0.1:3000/login/session-status', {credentials: 'include'})
       .then((response)=>response.json())
       .then((data)=>{
         if (data.id){
           setUser(data.id);
           if (!validPaths.includes(window.location.pathname)){ //go to home if you are not on any designated valid paths
+            console.log(window.location.pathname);
             navigate('/home');
           }
         } else{
@@ -39,9 +42,11 @@ function App() {
         <ThemeToggle />
       </div>
       <Routes>
+        <Route path='/' element={<h1>Welcome to Finetune</h1>} />
         <Route path="/welcome" element={<Welcome />} />
         <Route path="/home" element={<ProtectedHome />}/>
         <Route path="/newuser" element={<ProtectedNewUser />} />
+        <Route path="/loaduserspotify" element={<ProtectedLoadSpotify />} />
         {/*Everything except the welcome page is contingent on the user being logged in*/}
       </Routes>
     </div>

--- a/finetune-frontend/src/components/AddSongs.jsx
+++ b/finetune-frontend/src/components/AddSongs.jsx
@@ -1,0 +1,11 @@
+import { Button } from "./ui/button";
+
+const AddSongs = () => {
+    return (
+        <Button variant='outline' size='lg'
+            className='text-indigo !border-indigo flex-1 hover:text-darkpurple hover:!bg-indigo focus:scale-105 active:scale-105 p-3'
+            >Add Songs Manually</Button>
+    )
+}
+
+export default AddSongs;

--- a/finetune-frontend/src/components/LoginMenu.jsx
+++ b/finetune-frontend/src/components/LoginMenu.jsx
@@ -16,7 +16,7 @@ const LoginMenu = () => {
         const handleLogin = async (e) => {
             e.preventDefault();
             try {
-                const response = await fetch(`http://localhost:3000/login`, {
+                const response = await fetch(`http://127.0.0.1:3000/login`, {
                     method: "POST",
                     headers: {
                         "Content-Type": "application/json"

--- a/finetune-frontend/src/components/ProtectedRoute.jsx
+++ b/finetune-frontend/src/components/ProtectedRoute.jsx
@@ -10,7 +10,7 @@ const ProtectedRoute = (WrappedComponent) => {
 
         useEffect(()=>{
             if (!user){
-                fetch("http://localhost:3000/login/session-status", { credentials: "include"})
+                fetch("http://127.0.0.1:3000/login/session-status", { credentials: "include"})
                     .then((response)=>response.json())
                     .then((data)=>{
                         if (data.id){

--- a/finetune-frontend/src/components/RegisterModal.jsx
+++ b/finetune-frontend/src/components/RegisterModal.jsx
@@ -30,7 +30,7 @@ const RegisterModal = ({showModal, setShowModal}) => {
         if (!passwordValid) return;
         console.log('register')
         try {
-            const response = await fetch(`http://localhost:3000/login/register`, {
+            const response = await fetch(`http://127.0.0.1:3000/login/register`, {
                 method: "POST",
                 headers: {
                     "Content-Type": "application/json"
@@ -54,7 +54,7 @@ const RegisterModal = ({showModal, setShowModal}) => {
 
     const checkUsernameAvailability = async() => {
         try {
-            const response = await fetch(`http://localhost:3000/login/usernameAvailable?username=${username}`);
+            const response = await fetch(`http://127.0.0.1:3000/login/usernameAvailable?username=${username}`);
             if (!response.ok){
                 throw new Error('failed to check username');
             }

--- a/finetune-frontend/src/components/SpotifyAuth.jsx
+++ b/finetune-frontend/src/components/SpotifyAuth.jsx
@@ -53,7 +53,6 @@ const SpotifyAuth = () => {
         <div>
             <Button variant = 'outline' size='lg' className='text-palegreen !border-palegreen flex-1 hover:text-darkpurple hover:!bg-palegreen focus:scale-105 active:scale-105'
                 onClick={requestAuth}>Connect to Spotify</Button>
-            <Button onClick={()=>navigate('/loaduserspotify')}>Test</Button>
         </div>
     )
 }

--- a/finetune-frontend/src/components/SpotifyAuth.jsx
+++ b/finetune-frontend/src/components/SpotifyAuth.jsx
@@ -50,10 +50,9 @@ const SpotifyAuth = () => {
     }
 
     return (
-        <div>
-            <Button variant = 'outline' size='lg' className='text-palegreen !border-palegreen flex-1 hover:text-darkpurple hover:!bg-palegreen focus:scale-105 active:scale-105'
-                onClick={requestAuth}>Connect to Spotify</Button>
-        </div>
+        <Button variant = 'outline' size='lg' 
+            className='text-palegreen !border-palegreen flex-1 hover:text-darkpurple hover:!bg-palegreen focus:scale-105 active:scale-105 p-3'
+            onClick={requestAuth}>Connect to Spotify</Button>
     )
 }
 

--- a/finetune-frontend/src/components/SpotifyAuth.jsx
+++ b/finetune-frontend/src/components/SpotifyAuth.jsx
@@ -1,0 +1,61 @@
+import { Button } from "./ui/button";
+import { useNavigate } from "react-router-dom";
+
+const generateRandomString = (length) =>{
+    const possible = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890';
+    const values = crypto.getRandomValues(new Uint8Array(length));
+    return values.reduce((acc, x)=>acc + possible[x%possible.length], "");
+}
+
+const sha256 = async (plain) => {
+    const encoder = new TextEncoder();
+    const data = encoder.encode(plain);
+    return window.crypto.subtle.digest('SHA-256', data);
+}
+
+const base64encode = (input) => {
+    return btoa(String.fromCharCode(...new Uint8Array(input)))
+        .replace(/=/, '')
+        .replace(/\+/g, '-')
+        .replace(/\//g, '_');
+}
+
+const clientId = import.meta.env.VITE_SPOTIFY_CLIENT_ID
+const redirectUri = 'http://127.0.0.1:5173/loaduserspotify'
+
+const scope = 'user-top-read'
+const authUrl = new URL("https://accounts.spotify.com/authorize")
+
+const SpotifyAuth = () => {
+    const navigate = useNavigate();
+
+    const requestAuth = async () => {
+        //Send request to Spotify, will redirect to spotify's page
+        const codeVerifier = generateRandomString(64);
+        const hashed = await sha256(codeVerifier);
+        const codeChallenge = base64encode(hashed);
+
+        window.localStorage.setItem('code_verifier', codeVerifier);
+
+        const params = {
+            response_type: 'code',
+            client_id: clientId,
+            scope,
+            code_challenge_method: 'S256',
+            code_challenge: codeChallenge,
+            redirect_uri: redirectUri,
+        }
+        authUrl.search = new URLSearchParams(params).toString();
+        window.location.href = authUrl.toString();
+    }
+
+    return (
+        <div>
+            <Button variant = 'outline' size='lg' className='text-palegreen !border-palegreen flex-1 hover:text-darkpurple hover:!bg-palegreen focus:scale-105 active:scale-105'
+                onClick={requestAuth}>Connect to Spotify</Button>
+            <Button onClick={()=>navigate('/loaduserspotify')}>Test</Button>
+        </div>
+    )
+}
+
+export default SpotifyAuth;

--- a/finetune-frontend/src/pages/LoadUserSpotify.jsx
+++ b/finetune-frontend/src/pages/LoadUserSpotify.jsx
@@ -1,0 +1,57 @@
+import { useEffect } from "react";
+
+const clientId = import.meta.env.VITE_SPOTIFY_CLIENT_ID
+const redirectUri = 'http://127.0.0.1:5173/loaduserspotify'
+
+
+const LoadUserSpotify = () => {
+
+    const requestAccessToken = async(code) => {
+        const codeVerifier = localStorage.getItem('code_verifier');
+        const url = "https://accounts/spotify.com/api/token";
+        const payload = {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/x-www-form-urlencoded',
+            },
+            body: new URLSearchParams({
+                client_id: clientId,
+                grant_type: 'authorization_code',
+                code,
+                redirect_uri: redirectUri,
+                code_verifier: codeVerifier,
+            }),
+        }
+
+        try {
+            const body = await fetch(url, payload);
+            const response = await body.json();
+            if (!response || !response.ok){
+                throw new Error('failed to get spotify access token');
+            }
+            //TODO: USE response.access_token TO LOAD SPOTIFY 
+            //PUT response.refresh_token IN THE DB
+        } catch(error){
+            console.error(error);
+        }
+    }
+
+
+    useEffect(()=>{
+        const urlParams = new URLSearchParams(window.location.search);
+        let code = urlParams.get('code');
+        if (urlParams.get('error')){
+            console.error('failed to retrieve users spotify information');
+        }
+
+    }, [])
+
+
+    return (
+        <div>
+            <h1 className='font-fredoka' >Loading Your Spotify details...</h1>
+        </div>
+    )
+}
+
+export default LoadUserSpotify;

--- a/finetune-frontend/src/pages/LoadUserSpotify.jsx
+++ b/finetune-frontend/src/pages/LoadUserSpotify.jsx
@@ -1,4 +1,5 @@
 import { useEffect } from "react"
+import { useNavigate } from "react-router-dom"
 import { useAuth } from "@/components/AuthProvider"
 
 const clientId = import.meta.env.VITE_SPOTIFY_CLIENT_ID
@@ -7,6 +8,7 @@ const redirectUri = 'http://127.0.0.1:5173/loaduserspotify'
 
 const LoadUserSpotify = () => {
     const { user } = useAuth();
+    const navigate = useNavigate();
     
     const patchRefreshToken = async(refreshToken) => {
         try {
@@ -20,7 +22,7 @@ const LoadUserSpotify = () => {
                 })
             })
             if (!response || !response.ok){
-                console.error(error);
+                throw new Error('failed to update refresh token')
             }
         } catch(error){
             console.error(error);
@@ -45,12 +47,14 @@ const LoadUserSpotify = () => {
         }
         try {
             const body = await fetch(url, payload);
-            if (!body || !body.ok){
-                throw new Error('failed to get spotify access token');
-            }
+            //The reason this is commented out is documented below
+            // if (!body || !body.ok){
+            //     throw new Error('failed to get spotify access token');
+            // }
             const response = await body.json();
             patchRefreshToken(response.refresh_token);
             //TODO: USE response.access_token TO LOAD SPOTIFY 
+            navigate('/home');
         } catch(error){
             console.error(error);
         }

--- a/finetune-frontend/src/pages/NewUser.jsx
+++ b/finetune-frontend/src/pages/NewUser.jsx
@@ -1,0 +1,12 @@
+
+
+const NewUser = () => {
+    return (
+        <div>
+            <h1 className='font-fredoka'>Welcome to Finetune!</h1>
+        </div>
+    )
+}
+
+
+export default NewUser;

--- a/finetune-frontend/src/pages/NewUser.jsx
+++ b/finetune-frontend/src/pages/NewUser.jsx
@@ -1,9 +1,11 @@
 import SpotifyAuth from "@/components/SpotifyAuth";
+import AddSongs from "@/components/AddSongs";
 
 const NewUser = () => {
     return (
-        <div className='z-1 bg-background rounded-4xl p-5'>
-            <SpotifyAuth/>
+        <div className='z-1 bg-background rounded-4xl p-5 flex flex-col gap-5'>
+            <SpotifyAuth />
+            <AddSongs />
         </div>
     )
 }

--- a/finetune-frontend/src/pages/NewUser.jsx
+++ b/finetune-frontend/src/pages/NewUser.jsx
@@ -1,9 +1,9 @@
-
+import SpotifyAuth from "@/components/SpotifyAuth";
 
 const NewUser = () => {
     return (
-        <div>
-            <h1 className='font-fredoka'>Welcome to Finetune!</h1>
+        <div className='z-1 bg-background rounded-4xl p-5'>
+            <SpotifyAuth/>
         </div>
     )
 }

--- a/finetune-frontend/src/util/spotifyUtils.js
+++ b/finetune-frontend/src/util/spotifyUtils.js
@@ -1,0 +1,7 @@
+
+
+const getUsersTopTracks = () => {
+
+}
+
+export { getUsersTopTracks }

--- a/finetune-frontend/vite.config.js
+++ b/finetune-frontend/vite.config.js
@@ -14,4 +14,7 @@ export default defineConfig({
       "@": path.resolve(__dirname, "./src"),
     },
   },
+  server: {
+    host: true,
+  }
 });

--- a/finetune-node-backend/index.js
+++ b/finetune-node-backend/index.js
@@ -6,8 +6,20 @@ const PORT = process.env.PORT || 3000
 const loginRoutes = require('./routes/loginRoutes')
 const session = require('express-session')
 
+const allowedOrigins = [
+    'http://localhost:5173',
+    'http://127.0.0.1:5173'
+]
+
 app.use(cors({
-    origin: 'http://localhost:5173',
+    origin: (origin, callback)=>{
+        if (!origin) return callback(null, true);
+        if (allowedOrigins.includes(origin)){
+            callback(null, true);
+        } else{
+            callback(new Error('Not allowed by CORS'))
+        }
+    },
     credentials: true
 }));
 app.use(express.json());

--- a/finetune-node-backend/index.js
+++ b/finetune-node-backend/index.js
@@ -4,22 +4,11 @@ const cors = require('cors')
 const app = express()
 const PORT = process.env.PORT || 3000
 const loginRoutes = require('./routes/loginRoutes')
+const spotifyRoutes = require('./routes/spotifyRoutes')
 const session = require('express-session')
 
-const allowedOrigins = [
-    'http://localhost:5173',
-    'http://127.0.0.1:5173'
-]
 
 app.use(cors({
-    // origin: (origin, callback)=>{
-    //     if (!origin) return callback(null, true);
-    //     if (allowedOrigins.includes(origin)){
-    //         callback(null, true);
-    //     } else{
-    //         callback(new Error('Not allowed by CORS'))
-    //     }
-    // },
     origin: 'http://127.0.0.1:5173',
     credentials: true
 }));
@@ -37,6 +26,8 @@ app.use(session({
 
 
 app.use('/login', loginRoutes)
+app.use('/spotify', spotifyRoutes)
+
 
 app.get('/', (req, res)=>{
     res.send("welcome to finetune");

--- a/finetune-node-backend/index.js
+++ b/finetune-node-backend/index.js
@@ -12,14 +12,15 @@ const allowedOrigins = [
 ]
 
 app.use(cors({
-    origin: (origin, callback)=>{
-        if (!origin) return callback(null, true);
-        if (allowedOrigins.includes(origin)){
-            callback(null, true);
-        } else{
-            callback(new Error('Not allowed by CORS'))
-        }
-    },
+    // origin: (origin, callback)=>{
+    //     if (!origin) return callback(null, true);
+    //     if (allowedOrigins.includes(origin)){
+    //         callback(null, true);
+    //     } else{
+    //         callback(new Error('Not allowed by CORS'))
+    //     }
+    // },
+    origin: 'http://127.0.0.1:5173',
     credentials: true
 }));
 app.use(express.json());
@@ -42,6 +43,6 @@ app.get('/', (req, res)=>{
 })
 
 
-app.listen(PORT, ()=>{
-    console.log(`Server is running on http://localhost:${PORT}`);
+app.listen(PORT, '127.0.0.1', ()=>{
+    console.log(`Server is running on http://127.0.0.1:${PORT}`);
 })

--- a/finetune-node-backend/prisma/migrations/20250630230526_first_song_table/migration.sql
+++ b/finetune-node-backend/prisma/migrations/20250630230526_first_song_table/migration.sql
@@ -1,0 +1,29 @@
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN     "displayName" TEXT,
+ADD COLUMN     "spotifyRefreshToken" TEXT;
+
+-- CreateTable
+CREATE TABLE "Song" (
+    "id" TEXT NOT NULL,
+    "spotify_id" TEXT NOT NULL,
+    "title" TEXT NOT NULL,
+
+    CONSTRAINT "Song_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "_SongToUser" (
+    "A" TEXT NOT NULL,
+    "B" TEXT NOT NULL,
+
+    CONSTRAINT "_SongToUser_AB_pkey" PRIMARY KEY ("A","B")
+);
+
+-- CreateIndex
+CREATE INDEX "_SongToUser_B_index" ON "_SongToUser"("B");
+
+-- AddForeignKey
+ALTER TABLE "_SongToUser" ADD CONSTRAINT "_SongToUser_A_fkey" FOREIGN KEY ("A") REFERENCES "Song"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_SongToUser" ADD CONSTRAINT "_SongToUser_B_fkey" FOREIGN KEY ("B") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/finetune-node-backend/prisma/schema.prisma
+++ b/finetune-node-backend/prisma/schema.prisma
@@ -14,9 +14,19 @@ datasource db {
 }
 
 model User {
-  id             String   @id @default(uuid())
-  username       String   @unique
-  hashedPassword String
-  createdAt      DateTime @default(now())
-  updatedAt      DateTime @updatedAt
+  id                  String   @id @default(uuid())
+  username            String   @unique
+  hashedPassword      String
+  spotifyRefreshToken String?
+  displayName         String?
+  songs               Song[]
+  createdAt           DateTime @default(now())
+  updatedAt           DateTime @updatedAt
+}
+
+model Song {
+  id         String @id @default(uuid())
+  spotify_id String
+  title      String
+  users      User[]
 }

--- a/finetune-node-backend/routes/loginRoutes.js
+++ b/finetune-node-backend/routes/loginRoutes.js
@@ -26,7 +26,7 @@ router.post('/register', async(req, res)=>{
         }
 
         //Ensure username is not taken
-        const existingUser = await prisma.User.findUnique({where: {username}});
+        const existingUser = await prisma.user.findUnique({where: {username}});
         if (existingUser){
             return res.status(400).json({error: 'username taken'})
         }
@@ -51,7 +51,7 @@ router.post('/', async(req, res)=>{
         if (!username || !password){
             return res.status(400).json({error: "must include both a username and password"});
         }
-        const user = await prisma.User.findUnique({where: {username}});
+        const user = await prisma.user.findUnique({where: {username}});
         if (!user){
             return res.status(400).json({error: 'invalid username or password'});
         }
@@ -76,7 +76,7 @@ router.get('/session-status', async (req, res)=>{
         if (!req.session.userId){
             return res.status(401).json({message: 'not logged in'});
         }
-        const user = await prisma.User.findUnique({
+        const user = await prisma.user.findUnique({
             where: {id: req.session.userId},
             select: {username: true}
         })

--- a/finetune-node-backend/routes/spotifyRoutes.js
+++ b/finetune-node-backend/routes/spotifyRoutes.js
@@ -1,0 +1,27 @@
+const express = require('express')
+const router = express.Router()
+const { PrismaClient } = require('@prisma/client')
+const prisma = new PrismaClient()
+
+router.patch('/:id', async(req, res)=>{
+    try {
+        const userId = req.params.id;
+        const {refresh_token} = req.body;
+        if (!refresh_token){
+            return res.status(400).json({error: 'must include a refresh token'});
+        }
+        const updatedUser = await prisma.user.update({
+            where: {id: userId},
+            data: {
+                spotifyRefreshToken: refresh_token
+            }
+        });
+        res.json(updatedUser.id);
+    }catch (error){
+        res.status(500).json({error: 'server error'})
+    }
+})
+
+
+
+module.exports = router;


### PR DESCRIPTION
## Description

This PR creates the landing page once a user has registered. They have two options: connect their spotify or manually add songs. This PR has the functionality for connecting your spotify account, which involved approving the app on the Spotify Creator dashboard, using the Authorization Code with PKCE flow for Oauth2.0, creating a loading page for the app getting your Spotify information, and finally backend routes for storing the user's refresh token. 

One massive blocker I ran into was the fact that the Spotify dashboard does not accept localhost urls as callbacks, it must be in the form 127.0.0.1:port. I was attempting to make my app work with both, but the session management/cookie logic did not work so I had to troubleshoot. The current fix is running everything through 127.0.0.1, which means that the app does not work on localhost. This is fine for development, but once the app is deployed it will use a different session management system such as connect-pg-simple so that there are no CORS issues. 

Future PRs will implement logic for users manually adding songs. This will require querying spotify for songs that a user types in so that a user cannot add any song that is not in Spotify. 

The work done in this PR is very modular and will be directly applicable in the profile section of the app too so that users can re-update their song database after they have made an account. 

## Milestones
User Interface, Spotify Backend, Loading State

## Resources
I used the code snippets from the Spotify API endpoints giving examples on how to make the calls

## Test Plan
https://www.loom.com/share/9488e82788684dfdb25fd33a4b6b56b9?sid=374d2105-2107-4bb4-8bc7-89ce6d7389f4

This video demonstrates creating an account and connecting it to Spotify. If you slow it down on the moment it redirects after you approve, you can see a page that has a loading state for the site retrieving information and putting it in the database. 
