### PR TITLE
Manual add songs

### DIFF
--- a/finetune-frontend/src/components/AddSongs.jsx
+++ b/finetune-frontend/src/components/AddSongs.jsx
@@ -1,10 +1,105 @@
+import { useEffect, useState } from "react";
+
 import { Button } from "./ui/button";
+import { Input } from "./ui/input"
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog"
+
+import { useAuth } from "./AuthProvider";
+
+const clientId = import.meta.env.VITE_SPOTIFY_CLIENT_ID
+const clientSecret = import.meta.env.VITE_SPOTIFY_CLIENT_SECRET
+
 
 const AddSongs = () => {
+    const [searchString, setSearchString] = useState('');
+    const { user } = useAuth();
+    const [token, setToken] = useState(null);
+    const [searchResults, setSearchResults] = useState([]);
+
+    const fetchToken = async() => {
+        try {
+            const response = await fetch('https://accounts.spotify.com/api/token',{
+                method: 'POST',
+                headers: {
+                    'Authorization': 'Basic ' + btoa(clientId + ':' + clientSecret),
+                    'Content-Type': 'application/x-www-form-urlencoded'
+                },
+                body: new URLSearchParams({
+                    grant_type: 'client_credentials'
+                }),
+            })
+            if (!response || !response.ok){
+                throw new Error('failed to get client token');
+            }
+            const responseJSON = await response.json();
+            setToken(responseJSON.access_token);
+
+        } catch (error){
+            console.error(error);
+        }
+    }
+
+    const fetchSongs = async() => {
+        try {
+            const response = await fetch(`https://api.spotify.com/v1/search?q=${searchString}&type=track&limit=${20}`,{
+                headers: {
+                    'Authorization': 'Bearer ' + token
+                }
+            });
+            if (!response || !response.ok){
+                throw new Error('failed to search for songs');
+            }
+            const responseJSON = await response.json();
+            setSearchResults(responseJSON.tracks.items)
+            console.log(responseJSON);
+        } catch(error){
+            console.error(error);
+        }
+    }
+
+    const handleSearch = async() => {
+        fetchSongs();
+        console.log('search');
+    }
+
+    useEffect(()=>{
+        fetchToken();
+    },[])
+
+
     return (
-        <Button variant='outline' size='lg'
-            className='text-indigo !border-indigo flex-1 hover:text-darkpurple hover:!bg-indigo focus:scale-105 active:scale-105 p-3'
-            >Add Songs Manually</Button>
+        <Dialog>
+            <DialogTrigger asChild>
+                <Button variant='outline' size='lg'
+                    className='text-indigo !border-indigo flex-1 hover:text-darkpurple hover:!bg-indigo focus:scale-105 active:scale-105 p-3'
+                    >Add Songs Manually</Button>
+            </DialogTrigger>
+            <DialogContent>
+                <DialogHeader>
+                    <DialogTitle className='text-center text-5xl font-fredoka'>
+                        Manually Add Songs
+                    </DialogTitle>
+                    <DialogDescription className='font-fredoka'>
+                        Add songs that you either like or dislike to tailor the algorithm to your music taste!
+                    </DialogDescription>
+                </DialogHeader>
+                <div className='flex flex-row gap-2'>
+                    <Input placeholder='Search for a song' value={searchString} onChange={(e)=>setSearchString(e.target.value)} />
+                    {searchString && <Button variant='outline' size='sm'
+                        className='text-orange !border-orange hover:text-darkpurple hover:!bg-orange focus:scale-105 active:scale-105'
+                        onClick={handleSearch}>Search</Button>}
+                </div>
+            </DialogContent>
+        </Dialog>
     )
 }
 

--- a/finetune-frontend/src/components/AddSongs.jsx
+++ b/finetune-frontend/src/components/AddSongs.jsx
@@ -12,6 +12,7 @@ import {
   DialogTitle,
   DialogTrigger,
 } from "@/components/ui/dialog"
+import SongElement from "./SongElement";
 
 import { useAuth } from "./AuthProvider";
 
@@ -59,8 +60,7 @@ const AddSongs = () => {
                 throw new Error('failed to search for songs');
             }
             const responseJSON = await response.json();
-            setSearchResults(responseJSON.tracks.items)
-            console.log(responseJSON);
+            setSearchResults(responseJSON.tracks.items);
         } catch(error){
             console.error(error);
         }
@@ -68,7 +68,7 @@ const AddSongs = () => {
 
     const handleSearch = async() => {
         fetchSongs();
-        console.log('search');
+        console.log(searchResults);
     }
 
     useEffect(()=>{
@@ -83,7 +83,7 @@ const AddSongs = () => {
                     className='text-indigo !border-indigo flex-1 hover:text-darkpurple hover:!bg-indigo focus:scale-105 active:scale-105 p-3'
                     >Add Songs Manually</Button>
             </DialogTrigger>
-            <DialogContent>
+            <DialogContent className='w-900px'>
                 <DialogHeader>
                     <DialogTitle className='text-center text-5xl font-fredoka'>
                         Manually Add Songs
@@ -93,10 +93,25 @@ const AddSongs = () => {
                     </DialogDescription>
                 </DialogHeader>
                 <div className='flex flex-row gap-2'>
-                    <Input placeholder='Search for a song' value={searchString} onChange={(e)=>setSearchString(e.target.value)} />
+                    <Input placeholder='Search for a song' className='font-fredoka' value={searchString} onChange={(e)=>{
+                        setSearchString(e.target.value);
+                        setSearchResults([])
+                        }} />
                     {searchString && <Button variant='outline' size='sm'
                         className='text-orange !border-orange hover:text-darkpurple hover:!bg-orange focus:scale-105 active:scale-105'
                         onClick={handleSearch}>Search</Button>}
+                </div>
+                <div className='overflow-y-auto max-h-[400px] mt-4 flex flex-col gap-4' style={{scrollbarWidth: 'thin'}}>
+                    {searchResults.map((track)=>{
+                        return (
+                            <SongElement 
+                                name={track.name}
+                                artists={track.artists}
+                                image={track.album.images[0].url}
+                                key={track.id}
+                            />
+                        )
+                    })}
                 </div>
             </DialogContent>
         </Dialog>

--- a/finetune-frontend/src/components/RegisterModal.jsx
+++ b/finetune-frontend/src/components/RegisterModal.jsx
@@ -4,13 +4,9 @@ import { Button } from "./ui/button"
 import { Input } from "./ui/input"
 import {
   Dialog,
-  DialogClose,
   DialogContent,
-  DialogDescription,
-  DialogFooter,
   DialogHeader,
   DialogTitle,
-  DialogTrigger,
 } from "@/components/ui/dialog"
 import { useAuth } from "./AuthProvider"
 
@@ -90,10 +86,9 @@ const RegisterModal = ({showModal, setShowModal}) => {
             }}>
                 <DialogContent>
                     <DialogHeader>
-                        <DialogTitle>
+                        <DialogTitle className='text-center'>
                             <p  className='text-5xl font-fredoka'>Register User</p>
                         </DialogTitle>
-                        <DialogDescription></DialogDescription>
                     </DialogHeader>
                     <div>
                         <form className='flex flex-col gap-5' onSubmit={handleRegister}>

--- a/finetune-frontend/src/components/SongElement.jsx
+++ b/finetune-frontend/src/components/SongElement.jsx
@@ -1,0 +1,18 @@
+
+
+const SongElement = ({name, artists, image}) => {
+    return (
+        <div className='rounded-4xl border border-offwhite p-3 flex flex-row'>
+            <div className='flex flex-row gap-3'>
+                <img className='rounded-sm h-20 w-20' src={image} />
+                <div className='flex flex-col justify-between'>
+                    <p className='font-fredoka'>{name}</p>
+                    <p className='font-fredoka'>
+                        {artists.map(artist=>artist.name).join(', ')}</p>
+                </div>
+            </div>
+        </div>
+    )
+}
+
+export default SongElement;

--- a/finetune-frontend/src/components/SongElement.jsx
+++ b/finetune-frontend/src/components/SongElement.jsx
@@ -1,8 +1,9 @@
-
+import { Button } from "./ui/button";
+import { ThumbsDown, ThumbsUp } from "lucide-react";
 
 const SongElement = ({name, artists, image}) => {
     return (
-        <div className='rounded-4xl border border-offwhite p-3 flex flex-row'>
+        <div className='rounded-4xl border border-offwhite p-3 flex flex-row justify-between'>
             <div className='flex flex-row gap-3'>
                 <img className='rounded-sm h-20 w-20' src={image} />
                 <div className='flex flex-col justify-between'>
@@ -10,6 +11,14 @@ const SongElement = ({name, artists, image}) => {
                     <p className='font-fredoka'>
                         {artists.map(artist=>artist.name).join(', ')}</p>
                 </div>
+            </div>
+            <div className='flex flex-col justify-between gap-2'>
+                <Button variant='outline' size='sm'
+                    className='text-palegreen !border-palegreen hover:text-darkpurple hover:!bg-palegreen'
+                    ><ThumbsUp/></Button>
+                <Button variant='outline' size='sm'
+                    className='text-red !border-red hover:text-darkpurple hover:!bg-red'
+                    ><ThumbsDown/></Button>
             </div>
         </div>
     )


### PR DESCRIPTION
## Description

<what this pull request is doing>
<what will be done in later PRs and not included here>

This PR creates the frontend and spotify connection for searching songs and liking/disliking them. This will be information added to the user's song information so that the recommendation algorithm is more tailored to the user.

It also creates the components related to the Spotify Client Credentials Flow which will be very useful when doing other Spotify requests later for the app (allowing users who don't have spotify to use the site).

## Milestones
User Interface, Spotify Backend, Data Collection

## Resources
I used the Spotify API example usage of their endpoints.

## Test Plan
(https://www.loom.com/share/2f9bfaec50dd41dca36c752104acb46e?sid=26a9efa6-2a04-4e84-8dfd-df8643093748)
This demonstrates the song searching capabilities and the associated user interface. 