### PR TITLE
Add songs to backend

### DIFF
--- a/finetune-frontend/src/components/AddSongs.jsx
+++ b/finetune-frontend/src/components/AddSongs.jsx
@@ -75,8 +75,9 @@ const AddSongs = () => {
         fetchToken();
     },[])
 
-    const putSong = async(songId, albumId, like) => {
-
+    const clearSearch = () => {
+        setSearchString('');
+        setSearchResults([]);
     }
 
     return (
@@ -104,16 +105,17 @@ const AddSongs = () => {
                         className='text-orange !border-orange hover:text-darkpurple hover:!bg-orange focus:scale-105 active:scale-105'
                         onClick={handleSearch}>Search</Button>}
                 </div>
-                <div className='overflow-y-auto max-h-[400px] mt-4 flex flex-col gap-4' style={{scrollbarWidth: 'thin'}}>
+                {<div className='overflow-y-auto max-h-[400px] mt-4 flex flex-col gap-4' style={{scrollbarWidth: 'thin'}}>
                     {searchResults.map((track)=>{
                         return (
                             <SongElement 
                                 track={track}
                                 key={track.id}
+                                clear={clearSearch}
                             />
                         )
                     })}
-                </div>
+                </div>}
             </DialogContent>
         </Dialog>
     )

--- a/finetune-frontend/src/components/AddSongs.jsx
+++ b/finetune-frontend/src/components/AddSongs.jsx
@@ -75,6 +75,9 @@ const AddSongs = () => {
         fetchToken();
     },[])
 
+    const putSong = async(songId, albumId, like) => {
+
+    }
 
     return (
         <Dialog>

--- a/finetune-frontend/src/components/AddSongs.jsx
+++ b/finetune-frontend/src/components/AddSongs.jsx
@@ -108,9 +108,7 @@ const AddSongs = () => {
                     {searchResults.map((track)=>{
                         return (
                             <SongElement 
-                                name={track.name}
-                                artists={track.artists}
-                                image={track.album.images[0].url}
+                                track={track}
                                 key={track.id}
                             />
                         )

--- a/finetune-frontend/src/components/SongElement.jsx
+++ b/finetune-frontend/src/components/SongElement.jsx
@@ -1,7 +1,7 @@
 import { Button } from "./ui/button";
 import { ThumbsDown, ThumbsUp } from "lucide-react";
 
-const SongElement = ({track, addSong}) => {
+const SongElement = ({track, clear}) => {
     const name = track.name;
     const artists = track.artists;
     const image = track.album.images[0].url;
@@ -26,6 +26,7 @@ const SongElement = ({track, addSong}) => {
             // if (!response || !response.ok){
             //     throw new Error('failed to add song');
             // }
+            clear();
         } catch(error){
             console.error(error);
         }

--- a/finetune-frontend/src/components/SongElement.jsx
+++ b/finetune-frontend/src/components/SongElement.jsx
@@ -1,7 +1,36 @@
 import { Button } from "./ui/button";
 import { ThumbsDown, ThumbsUp } from "lucide-react";
 
-const SongElement = ({name, artists, image}) => {
+const SongElement = ({track, addSong}) => {
+    const name = track.name;
+    const artists = track.artists;
+    const image = track.album.images[0].url;
+
+    const handleAddSong = async(like) => {
+        try {
+            const response = await fetch(`http://127.0.0.1:3000/spotify/add_song`, {
+                method: "PATCH",
+                headers: {
+                    "Content-Type": "application/json",
+                },
+                body: JSON.stringify({
+                    like,
+                    spotify_id: track.id,
+                    title: name,
+                    album: track.album.name,
+                    spotify_album_id: track.album.id,
+                }),
+                credentials: 'include',
+            });
+            console.log(response);
+            // if (!response || !response.ok){
+            //     throw new Error('failed to add song');
+            // }
+        } catch(error){
+            console.error(error);
+        }
+    }
+
     return (
         <div className='rounded-4xl border border-offwhite p-3 flex flex-row justify-between'>
             <div className='flex flex-row gap-3'>
@@ -15,10 +44,10 @@ const SongElement = ({name, artists, image}) => {
             <div className='flex flex-col justify-between gap-2'>
                 <Button variant='outline' size='sm'
                     className='text-palegreen !border-palegreen hover:text-darkpurple hover:!bg-palegreen'
-                    ><ThumbsUp/></Button>
+                    onClick={()=>handleAddSong(true)}><ThumbsUp/></Button>
                 <Button variant='outline' size='sm'
                     className='text-red !border-red hover:text-darkpurple hover:!bg-red'
-                    ><ThumbsDown/></Button>
+                    onClick={()=>handleAddSong(false)}><ThumbsDown/></Button>
             </div>
         </div>
     )

--- a/finetune-frontend/src/components/SpotifyAuth.jsx
+++ b/finetune-frontend/src/components/SpotifyAuth.jsx
@@ -1,5 +1,4 @@
 import { Button } from "./ui/button";
-import { useNavigate } from "react-router-dom";
 
 const generateRandomString = (length) =>{
     const possible = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890';
@@ -27,7 +26,6 @@ const scope = 'user-top-read'
 const authUrl = new URL("https://accounts.spotify.com/authorize")
 
 const SpotifyAuth = () => {
-    const navigate = useNavigate();
 
     const requestAuth = async () => {
         //Send request to Spotify, will redirect to spotify's page

--- a/finetune-frontend/src/pages/LoadUserSpotify.jsx
+++ b/finetune-frontend/src/pages/LoadUserSpotify.jsx
@@ -22,9 +22,10 @@ const LoadUserSpotify = () => {
                 }),
                 credentials: 'include',
             })
-            if (!response || !response.ok){
-                throw new Error('failed to update refresh token')
-            }
+            console.log(response);
+            // if (!response || !response.ok){
+            //     throw new Error('failed to update refresh token')
+            // }
         } catch(error){
             console.error(error);
         }

--- a/finetune-frontend/src/pages/LoadUserSpotify.jsx
+++ b/finetune-frontend/src/pages/LoadUserSpotify.jsx
@@ -12,14 +12,15 @@ const LoadUserSpotify = () => {
     
     const patchRefreshToken = async(refreshToken) => {
         try {
-            const response = await fetch(`http://127.0.0.1:3000/spotify/${user}`, {
+            const response = await fetch(`http://127.0.0.1:3000/spotify/refresh_token`, {
                 method: "PATCH",
                 headers: {
                     "Content-Type": "application/json",
                 },
                 body: JSON.stringify({
                     refresh_token: refreshToken
-                })
+                }),
+                credentials: 'include',
             })
             if (!response || !response.ok){
                 throw new Error('failed to update refresh token')

--- a/finetune-node-backend/index.js
+++ b/finetune-node-backend/index.js
@@ -12,6 +12,8 @@ app.use(cors({
     origin: 'http://127.0.0.1:5173',
     credentials: true
 }));
+
+
 app.use(express.json());
 app.use(session({
     secret: 'finetune-music-recommendation',

--- a/finetune-node-backend/middleware/auth.js
+++ b/finetune-node-backend/middleware/auth.js
@@ -1,0 +1,9 @@
+const isAuthenticated = (req, res, next) => {
+    if (!req.session.userId){
+        return res.status(401).json({error: "You must be logged in to perform this action"});
+    }
+    next();
+}
+
+
+export {isAuthenticated};

--- a/finetune-node-backend/prisma/migrations/20250701202016_added_like_and_dislike_songs/migration.sql
+++ b/finetune-node-backend/prisma/migrations/20250701202016_added_like_and_dislike_songs/migration.sql
@@ -1,0 +1,48 @@
+/*
+  Warnings:
+
+  - You are about to drop the `_SongToUser` table. If the table is not empty, all the data it contains will be lost.
+
+*/
+-- DropForeignKey
+ALTER TABLE "_SongToUser" DROP CONSTRAINT "_SongToUser_A_fkey";
+
+-- DropForeignKey
+ALTER TABLE "_SongToUser" DROP CONSTRAINT "_SongToUser_B_fkey";
+
+-- DropTable
+DROP TABLE "_SongToUser";
+
+-- CreateTable
+CREATE TABLE "_LikedSongs" (
+    "A" TEXT NOT NULL,
+    "B" TEXT NOT NULL,
+
+    CONSTRAINT "_LikedSongs_AB_pkey" PRIMARY KEY ("A","B")
+);
+
+-- CreateTable
+CREATE TABLE "_DislikedSongs" (
+    "A" TEXT NOT NULL,
+    "B" TEXT NOT NULL,
+
+    CONSTRAINT "_DislikedSongs_AB_pkey" PRIMARY KEY ("A","B")
+);
+
+-- CreateIndex
+CREATE INDEX "_LikedSongs_B_index" ON "_LikedSongs"("B");
+
+-- CreateIndex
+CREATE INDEX "_DislikedSongs_B_index" ON "_DislikedSongs"("B");
+
+-- AddForeignKey
+ALTER TABLE "_LikedSongs" ADD CONSTRAINT "_LikedSongs_A_fkey" FOREIGN KEY ("A") REFERENCES "Song"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_LikedSongs" ADD CONSTRAINT "_LikedSongs_B_fkey" FOREIGN KEY ("B") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_DislikedSongs" ADD CONSTRAINT "_DislikedSongs_A_fkey" FOREIGN KEY ("A") REFERENCES "Song"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_DislikedSongs" ADD CONSTRAINT "_DislikedSongs_B_fkey" FOREIGN KEY ("B") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/finetune-node-backend/prisma/migrations/20250701205703_/migration.sql
+++ b/finetune-node-backend/prisma/migrations/20250701205703_/migration.sql
@@ -1,0 +1,10 @@
+/*
+  Warnings:
+
+  - Added the required column `album` to the `Song` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `spotify_album_id` to the `Song` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "Song" ADD COLUMN     "album" TEXT NOT NULL,
+ADD COLUMN     "spotify_album_id" TEXT NOT NULL;

--- a/finetune-node-backend/prisma/migrations/20250701205803_/migration.sql
+++ b/finetune-node-backend/prisma/migrations/20250701205803_/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[spotify_id]` on the table `Song` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- CreateIndex
+CREATE UNIQUE INDEX "Song_spotify_id_key" ON "Song"("spotify_id");

--- a/finetune-node-backend/prisma/schema.prisma
+++ b/finetune-node-backend/prisma/schema.prisma
@@ -19,14 +19,18 @@ model User {
   hashedPassword      String
   spotifyRefreshToken String?
   displayName         String?
-  songs               Song[]
+  likedSongs          Song[]   @relation("LikedSongs")
+  dislikedSongs       Song[]   @relation("DislikedSongs")
   createdAt           DateTime @default(now())
   updatedAt           DateTime @updatedAt
 }
 
 model Song {
-  id         String @id @default(uuid())
-  spotify_id String
-  title      String
-  users      User[]
+  id               String @id @default(uuid())
+  spotify_id       String @unique
+  title            String
+  album            String
+  spotify_album_id String
+  likedBy          User[] @relation("LikedSongs")
+  dislikedBy       User[] @relation("DislikedSongs")
 }

--- a/finetune-node-backend/routes/spotifyRoutes.js
+++ b/finetune-node-backend/routes/spotifyRoutes.js
@@ -26,8 +26,9 @@ router.patch('/refresh_token', isAuthenticated, async(req, res)=>{
 router.patch('/add_song', isAuthenticated, async(req, res)=>{
     try {
         const userId = req.session.userId;
+        console.log(userId);
         const {like, spotify_id, title, album, spotify_album_id} = req.body;
-        if (like !== 'true' && like !== 'false'){
+        if (like !== true && like !== false){
             return res.status(400).json({error: 'like must be either true or false'});
         }
         if (!spotify_id || !title || !album || !spotify_album_id){

--- a/finetune-node-backend/routes/spotifyRoutes.js
+++ b/finetune-node-backend/routes/spotifyRoutes.js
@@ -2,10 +2,11 @@ const express = require('express')
 const router = express.Router()
 const { PrismaClient } = require('@prisma/client')
 const prisma = new PrismaClient()
+const {isAuthenticated} = require('../middleware/auth')
 
-router.patch('/:id', async(req, res)=>{
+router.patch('/refresh_token', isAuthenticated, async(req, res)=>{
     try {
-        const userId = req.params.id;
+        const userId = req.session.userId;
         const {refresh_token} = req.body;
         if (!refresh_token){
             return res.status(400).json({error: 'must include a refresh token'});
@@ -18,10 +19,46 @@ router.patch('/:id', async(req, res)=>{
         });
         res.json(updatedUser.id);
     }catch (error){
-        res.status(500).json({error: 'server error'})
+        res.status(500).json({error: 'server error'});
     }
 })
 
+router.patch('/add_song', isAuthenticated, async(req, res)=>{
+    try {
+        const userId = req.session.userId;
+        const {like, spotify_id, title, album, spotify_album_id} = req.body;
+        if (like !== 'true' && like !== 'false'){
+            return res.status(400).json({error: 'like must be either true or false'});
+        }
+        if (!spotify_id || !title || !album || !spotify_album_id){
+            return res.status(400).json({error: 'must specify spotify id, title, album, and spotify album id'});
+        }
+        const song = await prisma.song.upsert({
+            where: { spotify_id },
+            update: {}, //do nothing if it exists
+            create: {
+                spotify_id,
+                title,
+                album,
+                spotify_album_id
+            },
+        });
+        const updatedUser = await prisma.user.update({
+            where: {id: userId},
+            data: {
+                likedSongs: like==='like' 
+                    ? {connect: {id: song.id}}
+                    : {disconnect: {id: song.id}},
+                dislikedSongs: like==='false'
+                    ? {connect: {id: song.id}}
+                    : {disconnect: {id: song.id}}
+            }
+        });
+        res.json(updatedUser.id);
+    } catch(error){
+        res.status(500).json({error: 'server error'});
+    }
+})
 
 
 module.exports = router;

--- a/finetune-node-backend/routes/spotifyRoutes.js
+++ b/finetune-node-backend/routes/spotifyRoutes.js
@@ -26,7 +26,6 @@ router.patch('/refresh_token', isAuthenticated, async(req, res)=>{
 router.patch('/add_song', isAuthenticated, async(req, res)=>{
     try {
         const userId = req.session.userId;
-        console.log(userId);
         const {like, spotify_id, title, album, spotify_album_id} = req.body;
         if (like !== true && like !== false){
             return res.status(400).json({error: 'like must be either true or false'});
@@ -47,10 +46,10 @@ router.patch('/add_song', isAuthenticated, async(req, res)=>{
         const updatedUser = await prisma.user.update({
             where: {id: userId},
             data: {
-                likedSongs: like==='like' 
+                likedSongs: like 
                     ? {connect: {id: song.id}}
                     : {disconnect: {id: song.id}},
-                dislikedSongs: like==='false'
+                dislikedSongs: !like
                     ? {connect: {id: song.id}}
                     : {disconnect: {id: song.id}}
             }


### PR DESCRIPTION
## Description

This PR created the backend routes for adding songs to a user's liked/disliked songs. It finishes implementation of manually adding songs to your profile and gives the framework for the users top Spotify songs to be added. The routes that I created are protected so that a user must be currently logged in to add songs, which is a necessary security feature. 

This is the end of the new user workflow, so future pull requests will be creating the home page and profile page.

## Milestones
Spotify Backend

## Resources
N/A

## Test Plan
Adding a song in the site causes it to be added to the backend successfully. 
