### PR TITLE
implemented logic for checking which instruments are present in songs

### DIFF
--- a/finetune-node-backend/prisma/migrations/20250717172744_instrument_recognition_table/migration.sql
+++ b/finetune-node-backend/prisma/migrations/20250717172744_instrument_recognition_table/migration.sql
@@ -1,0 +1,13 @@
+-- AlterTable
+ALTER TABLE "Song" ADD COLUMN     "instruments" DOUBLE PRECISION[];
+
+-- CreateTable
+CREATE TABLE "Instrument_Recognition" (
+    "id" SERIAL NOT NULL,
+    "instruments" TEXT[],
+    "weights" JSONB NOT NULL,
+    "means" JSONB NOT NULL,
+    "stds" JSONB NOT NULL,
+
+    CONSTRAINT "Instrument_Recognition_pkey" PRIMARY KEY ("id")
+);

--- a/finetune-node-backend/prisma/migrations/20250717205303_added_name_to_instrument_recognition_table_so_that_retrieving_makes_more_sense/migration.sql
+++ b/finetune-node-backend/prisma/migrations/20250717205303_added_name_to_instrument_recognition_table_so_that_retrieving_makes_more_sense/migration.sql
@@ -1,0 +1,12 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[name]` on the table `Instrument_Recognition` will be added. If there are existing duplicate values, this will fail.
+  - Added the required column `name` to the `Instrument_Recognition` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "Instrument_Recognition" ADD COLUMN     "name" TEXT NOT NULL;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Instrument_Recognition_name_key" ON "Instrument_Recognition"("name");

--- a/finetune-node-backend/prisma/schema.prisma
+++ b/finetune-node-backend/prisma/schema.prisma
@@ -12,6 +12,15 @@ datasource db {
   url      = env("DATABASE_URL")
 }
 
+model Instrument_Recognition {
+  id          Int      @id @default(autoincrement())
+  name        String   @unique
+  instruments String[]
+  weights     Json
+  means       Json
+  stds        Json
+}
+
 model User {
   id                  String   @id @default(uuid())
   username            String   @unique
@@ -37,6 +46,7 @@ model Song {
   recording_mbid String  @unique
   mfccs          Float[]
   isrc           String  @unique
+  instruments    Float[]
   recommendedTo  User[]  @relation("RecommendedSongs")
   dislikedBy     User[]  @relation("DislikedSongs")
   likedBy        User[]  @relation("LikedSongs")

--- a/finetune-python-backend/regression/logistic_regression.py
+++ b/finetune-python-backend/regression/logistic_regression.py
@@ -192,7 +192,7 @@ def logistic_reg(X, y, w_init, max_its=10**4, eta=3.5, terminating_condition=10*
 
 
 
-def run_k_fold_cross_validation_regression(data, num_folds=5, seed=1):
+def run_k_fold_cross_validation_regression(data, num_folds=5, seed=None):
     train, test = train_test_split(data, seed=seed) # Take out 20% of data to be used for testing
     print('made train test split')
 


### PR DESCRIPTION
## Description

This PR is finalizing instrument recognition. It adds the backend route for adding the odds of a given instrument being present in a song to the song in the database which will enable the find song recommendation function to test the odds of a given instrument being present in a song.

## Milestones
Instrument Recognition - TC2

## Resources
None

## Test Plan
This was tested by running the route using FastAPI docs and passing it a song id for a song in my database. It processes correctly. 
