### PR TITLE
implemented logic for uploading many songs at once to the database

### DIFF
--- a/finetune-node-backend/prisma/migrations/20250718212421_unavailable_songs_table/migration.sql
+++ b/finetune-node-backend/prisma/migrations/20250718212421_unavailable_songs_table/migration.sql
@@ -1,0 +1,6 @@
+-- CreateTable
+CREATE TABLE "Unavailable_Songs" (
+    "spotify_id" TEXT NOT NULL,
+
+    CONSTRAINT "Unavailable_Songs_pkey" PRIMARY KEY ("spotify_id")
+);

--- a/finetune-node-backend/prisma/schema.prisma
+++ b/finetune-node-backend/prisma/schema.prisma
@@ -21,6 +21,8 @@ model Instrument_Recognition {
   stds        Json
 }
 
+
+
 model User {
   id                  String   @id @default(uuid())
   username            String   @unique
@@ -50,4 +52,9 @@ model Song {
   recommendedTo  User[]  @relation("RecommendedSongs")
   dislikedBy     User[]  @relation("DislikedSongs")
   likedBy        User[]  @relation("LikedSongs")
+}
+
+
+model Unavailable_Songs {
+  spotify_id String @id
 }

--- a/finetune-node-backend/routes/spotifyRoutes.js
+++ b/finetune-node-backend/routes/spotifyRoutes.js
@@ -3,7 +3,7 @@ const router = express.Router()
 const { PrismaClient } = require('@prisma/client')
 const prisma = new PrismaClient()
 const {isAuthenticated} = require('../middleware/auth')
-const { checkIfInDatabase, addSongToDatabase, getRandomSpotifySong } = require('../utils/spotifyUtils')
+const { checkIfInDatabase, checkIfUnavailable, addSongToDatabase, getRandomSpotifySong, seedDatabase } = require('../utils/spotifyUtils')
 
 
 //This route adds a refresh token to a user's profile
@@ -33,6 +33,15 @@ router.get('/exists', isAuthenticated, async(req, res)=>{
         return res.status(404).json({error: 'must query for a spotify id'});
     }
     res.json(await checkIfInDatabase(spotify_id))
+})
+
+//Check if a song has already been looked up
+router.get('/unavailable', isAuthenticated, async(req, res)=>{
+    const { spotify_id } = req.query;
+    if (!req.query){
+        return res.status(404).json({error: 'must query for sa spotify id'})
+    }
+    res.json(await checkIfUnavailable(spotify_id));
 })
 
 //Add a song to the database
@@ -104,6 +113,16 @@ router.get('/random_song', async(req, res)=>{
 })
 
 
+//Seed the database with tons of spotify songs
+router.get('/seed_database', async(req, res)=>{
+    try{
+        res.json(await seedDatabase())
+    } catch(error){
+        res.status(500).json({error: 'server error'})
+    }
+})
+
+
 //Check if a user's algorithm needs to update
 router.get('/reg_updated', isAuthenticated, async(req, res)=>{
     try {
@@ -116,6 +135,8 @@ router.get('/reg_updated', isAuthenticated, async(req, res)=>{
         res.status(500).json({error: 'server error'})
     }
 })
+
+
 
 
 //Get a user's recommended songs


### PR DESCRIPTION
## Description

This PR is implementing the logic for getting thousands of songs from spotify and using them to seed my database. This will be used to get random songs from my database instead of spotify to make the algorithm more efficient. 

It also adds a table in the database for songs that you have already searched for that you couldn't find information for. This also makes adding songs more efficient so that the same song doesn't try and get added multiple times. 

## Milestones
Algorithm efficiency

## Resources
None

## Test Plan
I briefly tested the function and it works, but I will only actually know how it is working as it runs over the weekend.
