### PR TITLE
Instrument frontend

### DIFF
--- a/finetune-frontend/package-lock.json
+++ b/finetune-frontend/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@radix-ui/react-dialog": "^1.1.14",
         "@radix-ui/react-dropdown-menu": "^2.1.15",
+        "@radix-ui/react-select": "^2.2.5",
         "@radix-ui/react-slot": "^1.2.3",
         "@tailwindcss/vite": "^4.1.10",
         "class-variance-authority": "^0.7.1",
@@ -1063,6 +1064,12 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@radix-ui/number": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/number/-/number-1.1.1.tgz",
+      "integrity": "sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g==",
+      "license": "MIT"
+    },
     "node_modules/@radix-ui/primitive": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.2.tgz",
@@ -1487,6 +1494,49 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-select": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-select/-/react-select-2.2.5.tgz",
+      "integrity": "sha512-HnMTdXEVuuyzx63ME0ut4+sEMYW6oouHWNGUZc7ddvUWIcfCva/AMoqEW/3wnEllriMWBa0RHspCYnfCWJQYmA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/number": "1.1.1",
+        "@radix-ui/primitive": "1.1.2",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-dismissable-layer": "1.1.10",
+        "@radix-ui/react-focus-guards": "1.1.2",
+        "@radix-ui/react-focus-scope": "1.1.7",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-popper": "1.2.7",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1",
+        "@radix-ui/react-use-previous": "1.1.1",
+        "@radix-ui/react-visually-hidden": "1.2.3",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.6.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-slot": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
@@ -1590,6 +1640,21 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-use-previous": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-previous/-/react-use-previous-1.1.1.tgz",
+      "integrity": "sha512-2dHfToCj/pzca2Ck724OZ5L0EVrr3eHRNsG/b3xQJLA2hZpVCS99bLAX+hm1IHXDEnzU6by5z/5MIY794/a8NQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-use-rect": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-use-rect/-/react-use-rect-1.1.1.tgz",
@@ -1622,6 +1687,29 @@
       },
       "peerDependenciesMeta": {
         "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-visually-hidden": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-visually-hidden/-/react-visually-hidden-1.2.3.tgz",
+      "integrity": "sha512-pzJq12tEaaIhqjbzpCuv/OypJY/BPavOofm+dbab+MHLajy277+1lLm6JFcGgF5eskJ6mquGirhXY2GD/8u8Ug==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
           "optional": true
         }
       }

--- a/finetune-frontend/package.json
+++ b/finetune-frontend/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@radix-ui/react-dialog": "^1.1.14",
     "@radix-ui/react-dropdown-menu": "^2.1.15",
+    "@radix-ui/react-select": "^2.2.5",
     "@radix-ui/react-slot": "^1.2.3",
     "@tailwindcss/vite": "^4.1.10",
     "class-variance-authority": "^0.7.1",

--- a/finetune-frontend/src/components/InstrumentAmountSelector.jsx
+++ b/finetune-frontend/src/components/InstrumentAmountSelector.jsx
@@ -1,0 +1,9 @@
+
+
+const InstrumentAmountSelector = () => {
+    <div>
+
+    </div>
+}
+
+export default InstrumentAmountSelector

--- a/finetune-frontend/src/components/InstrumentAmountSelector.jsx
+++ b/finetune-frontend/src/components/InstrumentAmountSelector.jsx
@@ -1,9 +1,34 @@
 
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
 
-const InstrumentAmountSelector = () => {
-    <div>
+const InstrumentAmountSelector = ({setInstrumentAmount, instrument}) => {
 
-    </div>
+    return (
+        <div className='flex flex-col gap-2 items-center'>
+            <p className='font-fredoka text-md'>{instrument}</p>
+            <Select defaultValue={1} onValueChange={(value)=>setInstrumentAmount(value)}>
+                <SelectTrigger className="w-[180px]">
+                    <SelectValue placeholder={`How much ${instrument}?`} />
+                </SelectTrigger>
+                <SelectContent>
+                    <SelectGroup>
+                    <SelectLabel>Fruits</SelectLabel>
+                    <SelectItem value={0}>Less</SelectItem>
+                    <SelectItem value={1}>Indifferent</SelectItem>
+                    <SelectItem value={2}>Extra</SelectItem>
+                    </SelectGroup>
+                </SelectContent>
+            </Select>
+        </div>
+    )
 }
 
 export default InstrumentAmountSelector

--- a/finetune-frontend/src/components/InstrumentAmountSelector.jsx
+++ b/finetune-frontend/src/components/InstrumentAmountSelector.jsx
@@ -12,7 +12,7 @@ import {
 const InstrumentAmountSelector = ({setInstrumentAmount, instrument}) => {
 
     return (
-        <div className='flex flex-col gap-2 items-center'>
+        <div className='flex flex-row gap-2 items-center'>
             <p className='font-fredoka text-md'>{instrument}</p>
             <Select defaultValue={1} onValueChange={(value)=>setInstrumentAmount(value)}>
                 <SelectTrigger className="w-[180px]">

--- a/finetune-frontend/src/components/RecommendSong.jsx
+++ b/finetune-frontend/src/components/RecommendSong.jsx
@@ -14,6 +14,7 @@ import { ThumbsUp, ThumbsDown } from "lucide-react";
 import { useAuth } from "./AuthProvider";
 
 import { addSongToUser } from "@/util/spotifyUtils";
+import InstrumentAmountSelector from "./InstrumentAmountSelector";
 
 const RecommendSong = () => {
     const [recSpotifyId, setRecSpotifyId] = useState(null);
@@ -55,13 +56,19 @@ const RecommendSong = () => {
         if (needUpdate){
             toast('You have recently updated your liked/disliked songs so your algorithm needs to refresh. Please wait briefly.')
         }
-        const response = await fetch(`http://127.0.0.1:8000/recommend_song?user_id=${user}`);
+        const response = await fetch(`http://127.0.0.1:8000/recommend_song?user_id=${user}&cel=${cel}&cla=${cla}&flu=${flu}&gac=${gac}&gel=${gel}&org=${org}&pia=${pia}&sax=${sax}&tru=${tru}&vio=${vio}&voi=${voi}`);
         const song = await response.json()
+        if (song === null){
+            toast('There are no songs in the database that fit your music taste and instrument desires :(')
+        }
         setRecSpotifyId(song.spotify_id)
     }
 
     return (
-        <Dialog onOpenChange={()=>setRecSpotifyId(null)}>
+        <Dialog onOpenChange={()=>{
+            setRecSpotifyId(null);
+            setCustomizeMenu(false);
+        }}>
             <DialogTrigger asChild>
                 <Button variant='outline' size='lg'
                     className='text-red !border-red hover:text-background hover:!bg-red focus:scale-105 
@@ -77,19 +84,29 @@ const RecommendSong = () => {
                         Get a new song that FineTune knows you will like! This will only give you a song with a greater than 75% chance of you liking it.
                     </DialogDescription>
                 </DialogHeader>
-                <div className='flex flex-row gap-2 justify-center'>
-                    {!recSpotifyId && <div className='flex flex-row gap-2'>
+                <div className='flex flex-col gap-2 justify-center items-center flex-1'>
+                    {!recSpotifyId && <div className='flex flex-row gap-2 flex-1'>
                         <Button variant='outline' size='lg'
                         className='text-orange !border-orange hover:text-background hover:!bg-orange
-                        focus:scale-105 active:scale-105 p-3 border-2'
+                        focus:scale-105 active:scale-105 p-3 border-2 flex-1'
                         onClick={handleGetRecommendation}>Give me a song!</Button>
                         <Button variant='outline' size='lg'
                         className='text-indigo !border-indigo hover:text-background hover:!bg-indigo
-                        focus:scale-105 active:scale-105 p-3 border-2'
+                        focus:scale-105 active:scale-105 p-3 border-2 flex-1'
                         onClick={()=>setCustomizeMenu((prev)=>!prev)}>Customize</Button>
                         </div>}
-                    {customizeMenu && <div>
-
+                    {!recSpotifyId && customizeMenu && <div className='flex flex-col items-center'>
+                        <InstrumentAmountSelector instrument='Cello' setInstrumentAmount={setCel} />
+                        <InstrumentAmountSelector instrument='Clarinet' setInstrumentAmount={setCla} />
+                        <InstrumentAmountSelector instrument='Flute' setInstrumentAmount={setFlu} />
+                        <InstrumentAmountSelector instrument='Acoustic Guitar' setInstrumentAmount={setGac} />
+                        <InstrumentAmountSelector instrument='Electric Guitar' setInstrumentAmount={setGel} />
+                        <InstrumentAmountSelector instrument='Organ' setInstrumentAmount={setOrg} />
+                        <InstrumentAmountSelector instrument='Piano' setInstrumentAmount={setPia} />
+                        <InstrumentAmountSelector instrument='Saxophone' setInstrumentAmount={setSax} />
+                        <InstrumentAmountSelector instrument='Trumpet' setInstrumentAmount={setTru} />
+                        <InstrumentAmountSelector instrument='Violin' setInstrumentAmount={setVio} />
+                        <InstrumentAmountSelector instrument='Human Singing Voice' setInstrumentAmount={setVoi} />
                         </div>}
                     {recSpotifyId && <div className='flex flex-col w-full'>
                         <iframe data-testid="embed-iframe" className='rounded-lg' 

--- a/finetune-frontend/src/components/RecommendSong.jsx
+++ b/finetune-frontend/src/components/RecommendSong.jsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import {
   Dialog,
   DialogContent,
@@ -31,6 +31,24 @@ const RecommendSong = () => {
     const [vio, setVio] = useState(1);
     const [voi, setVoi] = useState(1);
     const { user } = useAuth();
+
+    const resetInstruments = () => {
+        setCel(1);
+        setCla(1);
+        setFlu(1);
+        setGac(1);
+        setGel(1);
+        setOrg(1);
+        setPia(1);
+        setSax(1);
+        setTru(1);
+        setVio(1);
+        setVoi(1);
+    }
+
+    useEffect(()=>{
+        resetInstruments()
+    }, [customizeMenu])
 
 
     const handleAddSong = async(like) => {

--- a/finetune-frontend/src/components/RecommendSong.jsx
+++ b/finetune-frontend/src/components/RecommendSong.jsx
@@ -17,6 +17,18 @@ import { addSongToUser } from "@/util/spotifyUtils";
 
 const RecommendSong = () => {
     const [recSpotifyId, setRecSpotifyId] = useState(null);
+    const [customizeMenu, setCustomizeMenu] = useState(false);
+    const [cel, setCel] = useState(1);
+    const [cla, setCla] = useState(1);
+    const [flu, setFlu] = useState(1);
+    const [gac, setGac] = useState(1);
+    const [gel, setGel] = useState(1);
+    const [org, setOrg] = useState(1);
+    const [pia, setPia] = useState(1);
+    const [sax, setSax] = useState(1);
+    const [tru, setTru] = useState(1);
+    const [vio, setVio] = useState(1);
+    const [voi, setVoi] = useState(1);
     const { user } = useAuth();
 
 
@@ -66,10 +78,19 @@ const RecommendSong = () => {
                     </DialogDescription>
                 </DialogHeader>
                 <div className='flex flex-row gap-2 justify-center'>
-                    {!recSpotifyId && <Button variant='outline' size='lg'
+                    {!recSpotifyId && <div className='flex flex-row gap-2'>
+                        <Button variant='outline' size='lg'
                         className='text-orange !border-orange hover:text-background hover:!bg-orange
                         focus:scale-105 active:scale-105 p-3 border-2'
-                        onClick={handleGetRecommendation}>Give me a song!</Button>}
+                        onClick={handleGetRecommendation}>Give me a song!</Button>
+                        <Button variant='outline' size='lg'
+                        className='text-indigo !border-indigo hover:text-background hover:!bg-indigo
+                        focus:scale-105 active:scale-105 p-3 border-2'
+                        onClick={()=>setCustomizeMenu((prev)=>!prev)}>Customize</Button>
+                        </div>}
+                    {customizeMenu && <div>
+
+                        </div>}
                     {recSpotifyId && <div className='flex flex-col w-full'>
                         <iframe data-testid="embed-iframe" className='rounded-lg' 
                         src={`https://open.spotify.com/embed/track/${recSpotifyId}?utm_source=generator`} 

--- a/finetune-frontend/src/components/ui/select.jsx
+++ b/finetune-frontend/src/components/ui/select.jsx
@@ -1,0 +1,164 @@
+import * as React from "react"
+import * as SelectPrimitive from "@radix-ui/react-select"
+import { CheckIcon, ChevronDownIcon, ChevronUpIcon } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+function Select({
+  ...props
+}) {
+  return <SelectPrimitive.Root data-slot="select" {...props} />;
+}
+
+function SelectGroup({
+  ...props
+}) {
+  return <SelectPrimitive.Group data-slot="select-group" {...props} />;
+}
+
+function SelectValue({
+  ...props
+}) {
+  return <SelectPrimitive.Value data-slot="select-value" {...props} />;
+}
+
+function SelectTrigger({
+  className,
+  size = "default",
+  children,
+  ...props
+}) {
+  return (
+    <SelectPrimitive.Trigger
+      data-slot="select-trigger"
+      data-size={size}
+      className={cn(
+        "border-input data-[placeholder]:text-muted-foreground [&_svg:not([class*='text-'])]:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 dark:hover:bg-input/50 flex w-fit items-center justify-between gap-2 rounded-md border bg-transparent px-3 py-2 text-sm whitespace-nowrap shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:h-9 data-[size=sm]:h-8 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}>
+      {children}
+      <SelectPrimitive.Icon asChild>
+        <ChevronDownIcon className="size-4 opacity-50" />
+      </SelectPrimitive.Icon>
+    </SelectPrimitive.Trigger>
+  );
+}
+
+function SelectContent({
+  className,
+  children,
+  position = "popper",
+  ...props
+}) {
+  return (
+    <SelectPrimitive.Portal>
+      <SelectPrimitive.Content
+        data-slot="select-content"
+        className={cn(
+          "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 relative z-50 max-h-(--radix-select-content-available-height) min-w-[8rem] origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border shadow-md",
+          position === "popper" &&
+            "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
+          className
+        )}
+        position={position}
+        {...props}>
+        <SelectScrollUpButton />
+        <SelectPrimitive.Viewport
+          className={cn("p-1", position === "popper" &&
+            "h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)] scroll-my-1")}>
+          {children}
+        </SelectPrimitive.Viewport>
+        <SelectScrollDownButton />
+      </SelectPrimitive.Content>
+    </SelectPrimitive.Portal>
+  );
+}
+
+function SelectLabel({
+  className,
+  ...props
+}) {
+  return (
+    <SelectPrimitive.Label
+      data-slot="select-label"
+      className={cn("text-muted-foreground px-2 py-1.5 text-xs", className)}
+      {...props} />
+  );
+}
+
+function SelectItem({
+  className,
+  children,
+  ...props
+}) {
+  return (
+    <SelectPrimitive.Item
+      data-slot="select-item"
+      className={cn(
+        "focus:bg-accent focus:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground relative flex w-full cursor-default items-center gap-2 rounded-sm py-1.5 pr-8 pl-2 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
+        className
+      )}
+      {...props}>
+      <span className="absolute right-2 flex size-3.5 items-center justify-center">
+        <SelectPrimitive.ItemIndicator>
+          <CheckIcon className="size-4" />
+        </SelectPrimitive.ItemIndicator>
+      </span>
+      <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
+    </SelectPrimitive.Item>
+  );
+}
+
+function SelectSeparator({
+  className,
+  ...props
+}) {
+  return (
+    <SelectPrimitive.Separator
+      data-slot="select-separator"
+      className={cn("bg-border pointer-events-none -mx-1 my-1 h-px", className)}
+      {...props} />
+  );
+}
+
+function SelectScrollUpButton({
+  className,
+  ...props
+}) {
+  return (
+    <SelectPrimitive.ScrollUpButton
+      data-slot="select-scroll-up-button"
+      className={cn("flex cursor-default items-center justify-center py-1", className)}
+      {...props}>
+      <ChevronUpIcon className="size-4" />
+    </SelectPrimitive.ScrollUpButton>
+  );
+}
+
+function SelectScrollDownButton({
+  className,
+  ...props
+}) {
+  return (
+    <SelectPrimitive.ScrollDownButton
+      data-slot="select-scroll-down-button"
+      className={cn("flex cursor-default items-center justify-center py-1", className)}
+      {...props}>
+      <ChevronDownIcon className="size-4" />
+    </SelectPrimitive.ScrollDownButton>
+  );
+}
+
+export {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectScrollDownButton,
+  SelectScrollUpButton,
+  SelectSeparator,
+  SelectTrigger,
+  SelectValue,
+}


### PR DESCRIPTION
## Description

This PR is implementing the frontend that allows users to specify wanting more or less of a given instrument. It allows the users to take advantage of TC 2 which identifies the presence of different instruments in songs based on its MFCCs. 

It implements a menu that allows users to specify their desired amount of any given instrument. The user experience is very straightforward. 

## Milestones
Instrument Recognition - Technical Challenge 2

## Resources
None

## Test Plan
https://www.loom.com/share/1606153decb147979aa0edc21db6cb03?sid=e867f720-67ca-46b6-be1a-49a07a3106d5

This video shows a user first specifying a single instrument and then multiple before getting different recommendations for each based on their instrument specifications.
